### PR TITLE
feat: add `extractWords` parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ call ddc#custom#patch_global('sourceParms', #{
       \   registers: '0123456789"+*#:',
       \   maxAbbrWidth: 100,
       \   ctrlCharHlGroup: 'Comment'
+      \   extractWords: v:true,
       \ }})
 
 " Optional: Set `ddc-source-option-mark` to indicate the source name.

--- a/doc/ddc-source-register.txt
+++ b/doc/ddc-source-register.txt
@@ -42,6 +42,7 @@ EXAMPLES					*ddc-source-register-examples*
 	      \   registers: '0123456789"+*#:',
 	      \   maxAbbrWidth: 100,
 	      \   ctrlCharHlGroup: 'Comment'
+	      \   extractWords: v:true,
 	      \ }})
 
 	" Optional: Set `ddc-source-option-mark` to indicate the source name.
@@ -79,6 +80,15 @@ ctrlCharHlGroup	(string)
 
 		Default: "SpecialKey"
 
+				      *ddc-source-register-param-extractWords*
+extractWords	(boolean)
+		Whether to extract words from the register value.
+		If true, each word in the register value will become a item.
+		If false, the register value is treated as a single item.
+		Note that words are extracted according to 'iskeyword' option.
+
+		Default: false
+
 
 ==============================================================================
 ITEM ATTRIBUTES				 *ddc-source-register-item-attributes*
@@ -102,6 +112,8 @@ kind		(string)
 		"c"	for |characterwise| text
 		"l"	for |linewise| text
 		"b"	for |blockwise-visual| text
+		"w"	for |word| (see |ddc-source-register-param-extractWords|)
+		""	otherwise
 
 				     *ddc-source-register-item-attribute-menu*
 menu		(string)


### PR DESCRIPTION
Adds a new `extractWords` parameter to the `ddc-source-register` source. When set to `true`, the source will extract words from the register contents, creating a candidate item for each word instead of treating the entire register contents as a single item.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an option to extract and display individual words from register contents as separate completion candidates.
- **Documentation**
  - Updated documentation and usage examples to describe the new word extraction option and its effects.
- **Chores**
  - Enhanced the README with configuration details for the new feature.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->