### PR TITLE
chore: disable fail-fast in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,6 +18,7 @@ defaults:
 jobs:
   check:
     strategy:
+      fail-fast: false
       matrix:
         runner:
           - ubuntu-latest
@@ -34,10 +35,13 @@ jobs:
           deno-version: "${{ matrix.deno_version }}"
 
       - name: Check
+        if: ${{ !cancelled() }}
         run: find . -iname '*.ts' | xargs deno check
 
       - name: Lint
+        if: ${{ !cancelled() }}
         run: deno lint
 
       - name: Check format
+        if: ${{ !cancelled() }}
         run: deno fmt --check


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated test workflow to improve reliability by preventing premature termination and ensuring steps only run if the workflow is not cancelled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->